### PR TITLE
close-bank-icon on CitizenDetails Page

### DIFF
--- a/CitizenDetails.php
+++ b/CitizenDetails.php
@@ -18,7 +18,7 @@
     </div>
     <center>
 <div class="jumbotron" style="background-color: pink">
-  <span style="margin-left: 700px;"><i><a href="CitizenCensus.php" style="color:red;font-size: 30px;"><i class="fa fa-user"></i>ADD CITIZEN<i class="fa fa-university"></a></span>
+  <span style="margin-left: 700px;"><i><a href="CitizenCensus.php" style="color:red;font-size: 30px;"><i class="fa fa-user"></i>ADD CITIZEN<i class="fa fa-university"></i></a></span>
             <table class="table table-dark">
               <thead>
                 <tr>


### PR DESCRIPTION
Close Bank icon on CitizenDatails Page.
Before the correction, the page was looking like this:
![CitizenDeatils](https://user-images.githubusercontent.com/33451367/145555646-b1526c65-0b92-4fe6-ae53-f3f4012ac2f7.PNG)

After the correction the page is looking like this:
![FinalCitizenDetailsCorrection](https://user-images.githubusercontent.com/33451367/145556202-eee16f2d-d23d-4e0a-b7f7-c097d8e675db.PNG)
